### PR TITLE
feat: refactor continues

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default tseslint.config(
       '**/dist/**',
       '**/example/**/*.js',
       '**/docs/**',
+      '**/test/**',
     ]
   },
   eslint.configs.recommended,

--- a/lib/ccs-credentials.ts
+++ b/lib/ccs-credentials.ts
@@ -1,0 +1,121 @@
+import {
+    EDHOC,
+    EdhocCredentialManager,
+    EdhocCredentials,
+    EdhocCredentialsFormat,
+    EdhocCredentialsKID,
+} from './edhoc';
+
+interface OwnCredential {
+    kid: number | Buffer;
+    ccsBytes: Buffer;
+    publicKey: Buffer;
+    privateKey: Buffer;
+}
+
+interface PeerCredential {
+    kid: number | Buffer;
+    ccsBytes: Buffer;
+    publicKey: Buffer;
+}
+
+/**
+ * Credential manager for CCS (CWT Claims Set) credentials identified by kid.
+ *
+ * Use `addOwnCredential()` to register the local party's credential (returned
+ * by `fetch()`) and `addPeerCredential()` for each remote party whose
+ * credentials should be accepted (matched during `verify()`).
+ */
+export class CCSCredentialManager implements EdhocCredentialManager {
+    private ownCredential: OwnCredential | null = null;
+    private peerCredentials: PeerCredential[] = [];
+
+    /**
+     * Register the local party's CCS credential.
+     *
+     * @param kid        - Key identifier (integer or Buffer)
+     * @param ccsBytes   - Raw CBOR-encoded CCS map
+     * @param publicKey  - Public key bytes (e.g. P-256 x-coordinate or x||y)
+     * @param privateKey - Private key bytes
+     */
+    addOwnCredential(
+        kid: number | Buffer,
+        ccsBytes: Buffer,
+        publicKey: Buffer,
+        privateKey: Buffer,
+    ): void {
+        this.ownCredential = { kid, ccsBytes, publicKey, privateKey };
+    }
+
+    /**
+     * Register a peer's CCS credential for verification.
+     *
+     * @param kid       - Key identifier (integer or Buffer)
+     * @param ccsBytes  - Raw CBOR-encoded CCS map
+     * @param publicKey - Public key bytes
+     */
+    addPeerCredential(
+        kid: number | Buffer,
+        ccsBytes: Buffer,
+        publicKey: Buffer,
+    ): void {
+        this.peerCredentials.push({ kid, ccsBytes, publicKey });
+    }
+
+    /**
+     * Return the local party's credentials for inclusion in an EDHOC message.
+     */
+    async fetch(_edhoc: EDHOC): Promise<EdhocCredentials> {
+        if (!this.ownCredential) {
+            throw new Error('No own credential configured. Call addOwnCredential() first.');
+        }
+
+        return {
+            format: EdhocCredentialsFormat.kid,
+            privateKey: this.ownCredential.privateKey,
+            publicKey: this.ownCredential.publicKey,
+            kid: {
+                kid: this.ownCredential.kid,
+                credentials: this.ownCredential.ccsBytes,
+                isCBOR: true,
+            },
+        } as EdhocCredentialsKID;
+    }
+
+    /**
+     * Verify received peer credentials by looking up the kid value among
+     * registered peer credentials.
+     */
+    async verify(_edhoc: EDHOC, credentials: EdhocCredentials): Promise<EdhocCredentials> {
+        if (credentials.format !== EdhocCredentialsFormat.kid) {
+            throw new Error('CCSCredentialManager only supports kid credentials format');
+        }
+
+        const kidCred = credentials as EdhocCredentialsKID;
+        const receivedKid = kidCred.kid.kid;
+
+        const peer = this.peerCredentials.find(p => {
+            if (typeof p.kid === 'number' && typeof receivedKid === 'number') {
+                return p.kid === receivedKid;
+            }
+            if (Buffer.isBuffer(p.kid) && Buffer.isBuffer(receivedKid)) {
+                return p.kid.equals(receivedKid);
+            }
+            return false;
+        });
+
+        if (!peer) {
+            throw new Error(`Unknown peer kid: ${receivedKid}`);
+        }
+
+        return {
+            format: EdhocCredentialsFormat.kid,
+            publicKey: peer.publicKey,
+            kid: {
+                kid: peer.kid,
+                credentials: peer.ccsBytes,
+                isCBOR: true,
+            },
+        } as EdhocCredentialsKID;
+    }
+}

--- a/lib/edhoc.ts
+++ b/lib/edhoc.ts
@@ -422,7 +422,6 @@ export class EDHOC {
         const peerCred = await this.credMgr.verify(this, peerCredPartial);
         this._peerCredentials = peerCred;
         const credR = getCredBytes(peerCred);
-        const idCredR = encodeIdCred(peerCred);
         const idCredRMap = encodeIdCredMap(peerCred);
         const credRCbor = encodeCredItem(peerCred, credR);
 
@@ -551,7 +550,6 @@ export class EDHOC {
         const peerCred = await this.credMgr.verify(this, peerCredPartial);
         this._peerCredentials = peerCred;
         const credI = getCredBytes(peerCred);
-        const idCredI = encodeIdCred(peerCred);
         const idCredIMap = encodeIdCredMap(peerCred);
         const credICbor = encodeCredItem(peerCred, credI);
 

--- a/lib/edhoc.ts
+++ b/lib/edhoc.ts
@@ -7,6 +7,8 @@ import {
     connectionIdToBytes,
     connectionIdFromCbor,
     encodeIdCred,
+    encodeIdCredMap,
+    encodeCredItem,
     decodeIdCred,
     getCredBytes,
     encodePlaintext,
@@ -44,7 +46,7 @@ export enum EdhocCredentialsFormat {
 
 export interface EdhocCredentials {
     format: EdhocCredentialsFormat;
-    privateKeyID?: Buffer;
+    privateKey?: Buffer;
     publicKey?: Buffer;
 }
 
@@ -81,17 +83,6 @@ export interface EdhocCredentialManager {
     verify(edhoc: EDHOC, credentials: EdhocCredentials): Promise<EdhocCredentials> | EdhocCredentials | never;
 }
 
-export enum EdhocKeyType {
-    MakeKeyPair,
-    KeyAgreement,
-    Signature,
-    Verify,
-    Extract,
-    Expand,
-    Encrypt,
-    Decrypt,
-}
-
 export type EdhocPublicKey = Buffer;
 export type EdhocPrivateKey = Buffer;
 
@@ -101,17 +92,15 @@ export interface PublicPrivateTuple {
 }
 
 export interface EdhocCryptoManager {
-    importKey(edhoc: EDHOC, keyType: EdhocKeyType, key: Buffer): Promise<Buffer> | Buffer | never;
-    destroyKey(edhoc: EDHOC, keyID: Buffer): Promise<boolean> | boolean | never;
-    makeKeyPair(edhoc: EDHOC, keyID: Buffer, privateKeySize: number, publicKeySize: number): Promise<PublicPrivateTuple> | PublicPrivateTuple | never;
-    keyAgreement(edhoc: EDHOC, keyID: Buffer, publicKey: EdhocPublicKey, privateKeySize: number): Promise<Buffer> | Buffer | never;
-    sign(edhoc: EDHOC, keyID: Buffer, input: Buffer, signatureSize: number): Promise<Buffer> | Buffer | never;
-    verify(edhoc: EDHOC, keyID: Buffer, input: Buffer, signature: Buffer): Promise<boolean> | boolean | never;
-    extract(edhoc: EDHOC, keyID: Buffer, salt: Buffer, keySize: number): Promise<Buffer> | Buffer | never;
-    expand(edhoc: EDHOC, keyID: Buffer, info: Buffer, keySize: number): Promise<Buffer> | Buffer | never;
-    encrypt(edhoc: EDHOC, keyID: Buffer, nonce: Buffer, aad: Buffer, plaintext: Buffer, size: number): Promise<Buffer> | Buffer | never;
-    decrypt(edhoc: EDHOC, keyID: Buffer, nonce: Buffer, aad: Buffer, ciphertext: Buffer, size: number): Promise<Buffer> | Buffer | never;
-    hash(edhoc: EDHOC, data: Buffer, hashSize: number): Promise<Buffer> | Buffer | never;
+    generateKeyPair(edhoc: EDHOC): Promise<PublicPrivateTuple> | PublicPrivateTuple | never;
+    keyAgreement(edhoc: EDHOC, privateKey: Buffer, peerPublicKey: Buffer): Promise<Buffer> | Buffer | never;
+    sign(edhoc: EDHOC, privateKey: Buffer, input: Buffer): Promise<Buffer> | Buffer | never;
+    verify(edhoc: EDHOC, publicKey: Buffer, input: Buffer, signature: Buffer): Promise<boolean> | boolean | never;
+    hkdfExtract(edhoc: EDHOC, ikm: Buffer, salt: Buffer): Promise<Buffer> | Buffer | never;
+    hkdfExpand(edhoc: EDHOC, prk: Buffer, info: Buffer, length: number): Promise<Buffer> | Buffer | never;
+    encrypt(edhoc: EDHOC, key: Buffer, nonce: Buffer, aad: Buffer, plaintext: Buffer): Promise<Buffer> | Buffer | never;
+    decrypt(edhoc: EDHOC, key: Buffer, nonce: Buffer, aad: Buffer, ciphertext: Buffer): Promise<Buffer> | Buffer | never;
+    hash(edhoc: EDHOC, input: Buffer): Promise<Buffer> | Buffer | never;
 }
 
 export type EdhocConnectionID = number | Buffer;
@@ -189,7 +178,7 @@ export class EDHOC {
     private _suiteParams: CipherSuiteParams;
 
     private _peerCid: EdhocConnectionID | null = null;
-    private _ephKeyId: Buffer | null = null;
+    private _ephPrivateKey: Buffer | null = null;
     private _ephPub: Buffer | null = null;
     private _peerEphPub: Buffer | null = null;
 
@@ -227,7 +216,7 @@ export class EDHOC {
         this._suite = this.cipherSuites[this.cipherSuites.length - 1];
         this._suiteParams = getCipherSuiteParams(this._suite);
         this._peerCid = null;
-        this._ephKeyId = null;
+        this._ephPrivateKey = null;
         this._ephPub = null;
         this._peerEphPub = null;
         this._th = null;
@@ -327,7 +316,7 @@ export class EDHOC {
 
         // ECDH → G_XY
         const gXY = Buffer.from(await this.crypto.keyAgreement(
-            this, this._ephKeyId!, this._peerEphPub!, this._suiteParams.eccKeyLength));
+            this, this._ephPrivateKey!, this._peerEphPub!));
         this.log('G_XY', gXY);
 
         // TH_2 = H( G_Y, H(message_1) )  — RFC 9528 §5.3.2
@@ -342,12 +331,14 @@ export class EDHOC {
         const cred = await this.credMgr.fetch(this);
         const credR = getCredBytes(cred);
         const idCredR = encodeIdCred(cred);
+        const idCredRMap = encodeIdCredMap(cred);
+        const credRCbor = encodeCredItem(cred, credR);
 
         // Static DH for methods 1, 3 (responder authenticates with static DH)
         let gRX: Buffer | undefined;
         if (this._method === EdhocMethod.Method1 || this._method === EdhocMethod.Method3) {
             gRX = Buffer.from(await this.crypto.keyAgreement(
-                this, cred.privateKeyID!, this._peerEphPub!, this._suiteParams.eccKeyLength));
+                this, cred.privateKey!, this._peerEphPub!));
         }
 
         // PRK_3e2m
@@ -355,16 +346,17 @@ export class EDHOC {
         this.log('PRK_3e2m', this._prk3e2m);
 
         // MAC_2 with context_2 = << C_R, ID_CRED_R, TH_2, CRED_R, ?EAD_2 >>
-        const context2 = this.buildContext(cbor.encode(this.connectionID), idCredR, this._th, credR, ead);
+        const context2 = this.buildContext(cbor.encode(this.connectionID), idCredRMap, this._th, credRCbor, ead);
         const mac2Len = this.macLength('responder');
         const mac2 = await this.kdf(this._prk3e2m, 2, context2, mac2Len);
         this.log('MAC_2', mac2);
 
         // Signature_or_MAC_2
-        const sigOrMac2 = await this.signOrMac('responder', cred, idCredR, this._th, credR, ead, mac2);
+        const sigOrMac2 = await this.signOrMac('responder', cred, idCredRMap, this._th, credRCbor, ead, mac2);
         this.log('Signature_or_MAC_2', sigOrMac2);
 
         // PLAINTEXT_2 = ( C_R, ID_CRED_R, Signature_or_MAC_2, ?EAD_2 )
+        // Uses compact idCredR (bare kid) for the wire format
         const pt2 = Buffer.concat([
             cbor.encode(this.connectionID),
             encodePlaintext(idCredR, sigOrMac2, ead),
@@ -377,7 +369,7 @@ export class EDHOC {
         this.log('CIPHERTEXT_2', ct2);
 
         // TH_3 = H( TH_2, PLAINTEXT_2, CRED_R )
-        this._th = await this.hash(Buffer.concat([cbor.encode(this._th), pt2, cbor.encode(credR)]));
+        this._th = await this.hash(Buffer.concat([cbor.encode(this._th), pt2, credRCbor]));
         this.log('TH_3', this._th);
 
         // message_2 = bstr( G_Y || CIPHERTEXT_2 )  — RFC 9528 §5.3.1
@@ -400,7 +392,7 @@ export class EDHOC {
 
         // ECDH → G_XY
         const gXY = Buffer.from(await this.crypto.keyAgreement(
-            this, this._ephKeyId!, gY, this._suiteParams.eccKeyLength));
+            this, this._ephPrivateKey!, gY));
         this.log('G_XY', gXY);
 
         // TH_2 = H( G_Y, H(message_1) )
@@ -431,12 +423,14 @@ export class EDHOC {
         this._peerCredentials = peerCred;
         const credR = getCredBytes(peerCred);
         const idCredR = encodeIdCred(peerCred);
+        const idCredRMap = encodeIdCredMap(peerCred);
+        const credRCbor = encodeCredItem(peerCred, credR);
 
         // Static DH for methods 1, 3
         let gRX: Buffer | undefined;
         if (this._method === EdhocMethod.Method1 || this._method === EdhocMethod.Method3) {
             gRX = Buffer.from(await this.crypto.keyAgreement(
-                this, this._ephKeyId!, peerCred.publicKey!, this._suiteParams.eccKeyLength));
+                this, this._ephPrivateKey!, peerCred.publicKey!));
         }
 
         // PRK_3e2m
@@ -444,17 +438,17 @@ export class EDHOC {
         this.log('PRK_3e2m', this._prk3e2m);
 
         // Verify MAC_2 / Signature_or_MAC_2
-        const context2 = this.buildContext(cbor.encode(this._peerCid), idCredR, this._th, credR,
+        const context2 = this.buildContext(cbor.encode(this._peerCid), idCredRMap, this._th, credRCbor,
             parsed.ead.length > 0 ? parsed.ead : undefined);
         const mac2Len = this.macLength('responder');
         const mac2 = await this.kdf(this._prk3e2m, 2, context2, mac2Len);
         this.log('MAC_2', mac2);
 
-        await this.verifySignatureOrMac('responder', peerCred, idCredR, this._th, credR,
+        await this.verifySignatureOrMac('responder', peerCred, idCredRMap, this._th, credRCbor,
             parsed.ead.length > 0 ? parsed.ead : undefined, mac2, parsed.signatureOrMac);
 
         // TH_3 = H( TH_2, PLAINTEXT_2, CRED_R )
-        this._th = await this.hash(Buffer.concat([cbor.encode(this._th), pt2, cbor.encode(credR)]));
+        this._th = await this.hash(Buffer.concat([cbor.encode(this._th), pt2, credRCbor]));
         this.log('TH_3', this._th);
 
         this._state = State.VERIFIED_M2;
@@ -469,12 +463,14 @@ export class EDHOC {
         const cred = await this.credMgr.fetch(this);
         const credI = getCredBytes(cred);
         const idCredI = encodeIdCred(cred);
+        const idCredIMap = encodeIdCredMap(cred);
+        const credICbor = encodeCredItem(cred, credI);
 
         // Static DH for methods 2, 3 (initiator authenticates with static DH)
         let gIX: Buffer | undefined;
         if (this._method === EdhocMethod.Method2 || this._method === EdhocMethod.Method3) {
             gIX = Buffer.from(await this.crypto.keyAgreement(
-                this, cred.privateKeyID!, this._peerEphPub!, this._suiteParams.eccKeyLength));
+                this, cred.privateKey!, this._peerEphPub!));
         }
 
         // PRK_4e3m
@@ -482,16 +478,17 @@ export class EDHOC {
         this.log('PRK_4e3m', this._prk4e3m);
 
         // MAC_3 with context_3 = << ID_CRED_I, TH_3, CRED_I, ?EAD_3 >>
-        const context3 = this.buildContext(null, idCredI, th3, credI, ead);
+        const context3 = this.buildContext(null, idCredIMap, th3, credICbor, ead);
         const mac3Len = this.macLength('initiator');
         const mac3 = await this.kdf(this._prk4e3m, 6, context3, mac3Len);
         this.log('MAC_3', mac3);
 
         // Signature_or_MAC_3
-        const sigOrMac3 = await this.signOrMac('initiator', cred, idCredI, th3, credI, ead, mac3);
+        const sigOrMac3 = await this.signOrMac('initiator', cred, idCredIMap, th3, credICbor, ead, mac3);
         this.log('Signature_or_MAC_3', sigOrMac3);
 
         // PLAINTEXT_3 = ( ID_CRED_I, Signature_or_MAC_3, ?EAD_3 )
+        // Uses compact idCredI (bare kid) for the wire format
         const pt3 = encodePlaintext(idCredI, sigOrMac3, ead);
         this.log('PLAINTEXT_3', pt3);
 
@@ -504,7 +501,7 @@ export class EDHOC {
         this.log('CIPHERTEXT_3', ct3);
 
         // TH_4 = H( TH_3, PLAINTEXT_3, CRED_I )
-        this._th = await this.hash(Buffer.concat([cbor.encode(th3), pt3, cbor.encode(credI)]));
+        this._th = await this.hash(Buffer.concat([cbor.encode(th3), pt3, credICbor]));
         this.log('TH_4', this._th);
 
         // PRK_out, PRK_exporter
@@ -555,13 +552,15 @@ export class EDHOC {
         this._peerCredentials = peerCred;
         const credI = getCredBytes(peerCred);
         const idCredI = encodeIdCred(peerCred);
+        const idCredIMap = encodeIdCredMap(peerCred);
+        const credICbor = encodeCredItem(peerCred, credI);
 
         // Static DH for methods 2, 3
         let gIX: Buffer | undefined;
         if (this._method === EdhocMethod.Method2 || this._method === EdhocMethod.Method3) {
-            if (this._ephKeyId) {
+            if (this._ephPrivateKey) {
                 gIX = Buffer.from(await this.crypto.keyAgreement(
-                    this, this._ephKeyId, peerCred.publicKey!, this._suiteParams.eccKeyLength));
+                    this, this._ephPrivateKey, peerCred.publicKey!));
             }
         }
 
@@ -569,16 +568,16 @@ export class EDHOC {
         this._prk4e3m = await this.derivePrk4e3m(th3, gIX);
 
         // Verify MAC_3
-        const context3 = this.buildContext(null, idCredI, th3, credI,
+        const context3 = this.buildContext(null, idCredIMap, th3, credICbor,
             parsed.ead.length > 0 ? parsed.ead : undefined);
         const mac3Len = this.macLength('initiator');
         const mac3 = await this.kdf(this._prk4e3m, 6, context3, mac3Len);
 
-        await this.verifySignatureOrMac('initiator', peerCred, idCredI, th3, credI,
+        await this.verifySignatureOrMac('initiator', peerCred, idCredIMap, th3, credICbor,
             parsed.ead.length > 0 ? parsed.ead : undefined, mac3, parsed.signatureOrMac);
 
         // TH_4
-        this._th = await this.hash(Buffer.concat([cbor.encode(th3), pt3, cbor.encode(credI)]));
+        this._th = await this.hash(Buffer.concat([cbor.encode(th3), pt3, credICbor]));
 
         // PRK_out, PRK_exporter
         this._prkOut = await this.kdf(this._prk4e3m, 7, this._th, this._suiteParams.hashLength);
@@ -654,27 +653,17 @@ export class EDHOC {
      *  info is a CBOR sequence: label, context, length (NOT array-wrapped) */
     private async kdf(prk: Buffer, label: number, context: Buffer, length: number): Promise<Buffer> {
         const info = encodeCborSequence(label, context, length);
-        const keyId = await this.crypto.importKey(this, EdhocKeyType.Expand, prk);
-        try {
-            return Buffer.from(await this.crypto.expand(this, keyId, info, length));
-        } finally {
-            await this.crypto.destroyKey(this, keyId);
-        }
+        return Buffer.from(await this.crypto.hkdfExpand(this, prk, info, length));
     }
 
     /** HKDF-Extract(IKM, salt) */
     private async hkdfExtract(ikm: Buffer, salt: Buffer): Promise<Buffer> {
-        const keyId = await this.crypto.importKey(this, EdhocKeyType.Extract, ikm);
-        try {
-            return Buffer.from(await this.crypto.extract(this, keyId, salt, this._suiteParams.hashLength));
-        } finally {
-            await this.crypto.destroyKey(this, keyId);
-        }
+        return Buffer.from(await this.crypto.hkdfExtract(this, ikm, salt));
     }
 
     /** Hash */
     private async hash(data: Buffer): Promise<Buffer> {
-        return Buffer.from(await this.crypto.hash(this, data, this._suiteParams.hashLength));
+        return Buffer.from(await this.crypto.hash(this, data));
     }
 
     // ── private helpers: PRK derivation ────────────────────────────────
@@ -691,7 +680,7 @@ export class EDHOC {
     /** PRK_4e3m: Methods 0,1 → PRK_3e2m; Methods 2,3 → Extract(SALT_4e3m, G_IX) */
     private async derivePrk4e3m(th3: Buffer, gIX?: Buffer): Promise<Buffer> {
         if ((this._method === EdhocMethod.Method2 || this._method === EdhocMethod.Method3) && gIX) {
-            const salt = await this.kdf(this._prk3e2m!, 7, th3, this._suiteParams.hashLength);
+            const salt = await this.kdf(this._prk3e2m!, 5, th3, this._suiteParams.hashLength);
             return this.hkdfExtract(gIX, salt);
         }
         return this._prk3e2m!;
@@ -700,17 +689,13 @@ export class EDHOC {
     // ── private helpers: ephemeral keys ────────────────────────────────
 
     private async generateEphemeralKey(): Promise<void> {
-        this._ephKeyId = await this.crypto.importKey(this, EdhocKeyType.MakeKeyPair, Buffer.alloc(0));
-        const kp = await this.crypto.makeKeyPair(
-            this, this._ephKeyId, this._suiteParams.eccKeyLength, this._suiteParams.eccKeyLength);
+        const kp = await this.crypto.generateKeyPair(this);
+        this._ephPrivateKey = Buffer.from(kp.privateKey);
         this._ephPub = Buffer.from(kp.publicKey);
     }
 
     private async destroyEphemeralKey(): Promise<void> {
-        if (this._ephKeyId) {
-            await this.crypto.destroyKey(this, this._ephKeyId);
-            this._ephKeyId = null;
-        }
+        this._ephPrivateKey = null;
     }
 
     // ── private helpers: MAC / Signature ───────────────────────────────
@@ -729,11 +714,11 @@ export class EDHOC {
 
     /** Build context bytes: << [C_R,] ID_CRED_x, TH, CRED_x, ?EAD >> */
     private buildContext(
-        cRCbor: Buffer | null, idCredCbor: Buffer, th: Buffer, credX: Buffer, ead?: EdhocEAD[],
+        cRCbor: Buffer | null, idCredCbor: Buffer, th: Buffer, credXCbor: Buffer, ead?: EdhocEAD[],
     ): Buffer {
         const parts: Buffer[] = [];
         if (cRCbor) parts.push(cRCbor);
-        parts.push(idCredCbor, cbor.encode(th), cbor.encode(credX));
+        parts.push(idCredCbor, cbor.encode(th), credXCbor);
         if (ead?.length) parts.push(encodeEadItems(ead));
         return Buffer.concat(parts);
     }
@@ -750,7 +735,7 @@ export class EDHOC {
         cred: EdhocCredentials,
         idCredCbor: Buffer,
         th: Buffer,
-        credX: Buffer,
+        credXCbor: Buffer,
         ead: EdhocEAD[] | undefined,
         mac: Buffer,
     ): Promise<Buffer> {
@@ -761,10 +746,10 @@ export class EDHOC {
         if (!usesSig) return mac;
 
         // Sig_structure = ["Signature1", << ID_CRED_x >>, << TH, CRED_x, ?EAD >>, MAC]
-        const externalAad = this.buildSigExternalAad(th, credX, ead);
+        const externalAad = this.buildSigExternalAad(th, credXCbor, ead);
         const sigStructure = cbor.encode(['Signature1', idCredCbor, externalAad, mac]);
         return Buffer.from(await this.crypto.sign(
-            this, cred.privateKeyID!, sigStructure, this._suiteParams.eccSignLength));
+            this, cred.privateKey!, sigStructure));
     }
 
     /** Verify Signature_or_MAC from the peer */
@@ -773,7 +758,7 @@ export class EDHOC {
         peerCred: EdhocCredentials,
         idCredCbor: Buffer,
         th: Buffer,
-        credX: Buffer,
+        credXCbor: Buffer,
         ead: EdhocEAD[] | undefined,
         mac: Buffer,
         received: Buffer,
@@ -787,20 +772,15 @@ export class EDHOC {
             return;
         }
 
-        const externalAad = this.buildSigExternalAad(th, credX, ead);
+        const externalAad = this.buildSigExternalAad(th, credXCbor, ead);
         const sigStructure = cbor.encode(['Signature1', idCredCbor, externalAad, mac]);
 
-        const verifyKeyId = await this.crypto.importKey(this, EdhocKeyType.Verify, peerCred.publicKey!);
-        try {
-            await this.crypto.verify(this, verifyKeyId, sigStructure, received);
-        } finally {
-            await this.crypto.destroyKey(this, verifyKeyId);
-        }
+        await this.crypto.verify(this, peerCred.publicKey!, sigStructure, received);
     }
 
     /** Build the external_aad bstr for Sig_structure: concatenation of CBOR items */
-    private buildSigExternalAad(th: Buffer, credX: Buffer, ead?: EdhocEAD[]): Buffer {
-        const parts = [cbor.encode(th), cbor.encode(credX)];
+    private buildSigExternalAad(th: Buffer, credXCbor: Buffer, ead?: EdhocEAD[]): Buffer {
+        const parts = [cbor.encode(th), credXCbor];
         if (ead?.length) parts.push(encodeEadItems(ead));
         return Buffer.concat(parts);
     }
@@ -808,23 +788,11 @@ export class EDHOC {
     // ── private helpers: AEAD ──────────────────────────────────────────
 
     private async aeadEncrypt(key: Buffer, iv: Buffer, aad: Buffer, pt: Buffer): Promise<Buffer> {
-        const keyId = await this.crypto.importKey(this, EdhocKeyType.Encrypt, key);
-        try {
-            return Buffer.from(await this.crypto.encrypt(
-                this, keyId, iv, aad, pt, pt.length + this._suiteParams.aeadTagLength));
-        } finally {
-            await this.crypto.destroyKey(this, keyId);
-        }
+        return Buffer.from(await this.crypto.encrypt(this, key, iv, aad, pt));
     }
 
     private async aeadDecrypt(key: Buffer, iv: Buffer, aad: Buffer, ct: Buffer): Promise<Buffer> {
-        const keyId = await this.crypto.importKey(this, EdhocKeyType.Decrypt, key);
-        try {
-            return Buffer.from(await this.crypto.decrypt(
-                this, keyId, iv, aad, ct, ct.length - this._suiteParams.aeadTagLength));
-        } finally {
-            await this.crypto.destroyKey(this, keyId);
-        }
+        return Buffer.from(await this.crypto.decrypt(this, key, iv, aad, ct));
     }
 
     // ── private helpers: misc ──────────────────────────────────────────

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from "./edhoc";
 export * from "./crypto";
 export * from "./x509credentials";
+export * from "./ccs-credentials";

--- a/lib/x509credentials.ts
+++ b/lib/x509credentials.ts
@@ -6,12 +6,12 @@ export class X509CertificateCredentialManager implements EdhocCredentialManager 
     private certificates: X509Certificate[] = [];
     private peerCertificates: X509Certificate[] = [];
     private trustedCAs: X509Certificate[] = [];
-    private cryptoKeyID: Buffer;
+    private privateKey: Buffer;
 
     fetchFormat: EdhocCredentialsFormat = EdhocCredentialsFormat.x5chain;
 
-    constructor(credentials: X509Certificate[] | Buffer[], cryptoKeyID: Buffer) {
-        this.cryptoKeyID = cryptoKeyID;
+    constructor(credentials: X509Certificate[] | Buffer[], privateKey: Buffer) {
+        this.privateKey = privateKey;
         this.certificates = this.convertAndValidateCredentials(credentials);
     }
 
@@ -45,7 +45,7 @@ export class X509CertificateCredentialManager implements EdhocCredentialManager 
             case EdhocCredentialsFormat.x5chain: {
                 const chain: EdhocCredentialsCertificateChain = {
                     format: EdhocCredentialsFormat.x5chain,
-                    privateKeyID: this.cryptoKeyID,
+                    privateKey: this.privateKey,
                     x5chain: { 
                         certificates: this.certificates.map(cert => cert.raw)
                     }
@@ -58,7 +58,7 @@ export class X509CertificateCredentialManager implements EdhocCredentialManager 
                 }
                 const hash: EdhocCredentialsCertificateHash = {
                     format: EdhocCredentialsFormat.x5t,
-                    privateKeyID: this.cryptoKeyID,
+                    privateKey: this.privateKey,
                     x5t: {
                         certificate: this.certificates[0].raw,
                         hash: Buffer.from(this.certificates[0].fingerprint256.replace(/:/g, ''), 'hex').subarray(0, 8),

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,28 +1,34 @@
 import { randomBytes } from 'crypto';
-import { EDHOC, X509CertificateCredentialManager, DefaultEdhocCryptoManager, EdhocMethod, EdhocSuite, EdhocKeyType } from '../dist/index'
+import { EDHOC, X509CertificateCredentialManager, DefaultEdhocCryptoManager, EdhocMethod, EdhocSuite, PublicPrivateTuple } from '../dist/index'
 
 describe('EDHOC Handshake', () => {
     // Test setup variables
     const trustedCA = Buffer.from('308201323081DAA003020102021478408C6EC18A1D452DAE70C726CB0192A6116DBB300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333635335A170D3235313031393138333635335A301A3118301606035504030C0F5468697320697320434120526F6F743059301306072A8648CE3D020106082A8648CE3D03010703420004B9348A8A267EF52CFDC30109A29008A2D99F6B8F78BA9EAF5D51578C06134E78CB90A073EDC2488A14174B4E2997C840C5DE7F8E35EB54A0DB6977E894D1B2CB300A06082A8648CE3D040302034700304402203B92BFEC770B0FA4E17F8F02A13CD945D914ED8123AC85C37C8C7BAA2BE3E0F102202CB2DC2EC295B5F4B7BB631ED751179C145D6B6E081559AEA38CE215369E9C31', 'hex');
     let initiator: EDHOC;
     let responder: EDHOC;
-    
+
     let staticDhKeyInitiator: Buffer;
     let staticDhKeyResponder: Buffer;
-    
+
     let initiatorCredentialManager: X509CertificateCredentialManager;
     let responderCredentialManager: X509CertificateCredentialManager;
 
     class StaticCryptoManager extends DefaultEdhocCryptoManager {
 
-        async importKey(edhoc: EDHOC, keyType: EdhocKeyType, key: Buffer) {
-            if (keyType === EdhocKeyType.MakeKeyPair && key && edhoc.connectionID === 10) {
-                key = staticDhKeyInitiator
+        generateKeyPair(edhoc: EDHOC): PublicPrivateTuple {
+            // Use a fixed ephemeral key per connection ID so message_1 is deterministic
+            let privateKey: Buffer;
+            if (edhoc.connectionID === 10) {
+                privateKey = staticDhKeyInitiator;
+            } else if (edhoc.connectionID === 20) {
+                privateKey = staticDhKeyResponder;
+            } else {
+                return super.generateKeyPair(edhoc);
             }
-            if (keyType === EdhocKeyType.MakeKeyPair && key && edhoc.connectionID === 20) {
-                key = staticDhKeyResponder
-            }
-            return super.importKey(edhoc, keyType, key);
+            // Derive the public key from the fixed private key using the parent's key agreement curve
+            const { p256 } = require('@noble/curves/p256');
+            const publicKey = Buffer.from(p256.getPublicKey(privateKey)).subarray(1);
+            return { publicKey, privateKey };
         }
     }
 
@@ -33,25 +39,21 @@ describe('EDHOC Handshake', () => {
 
     beforeEach(() => {
         // Initialize credentials and crypto managers for both parties
-        const initiatorKeyID = Buffer.from('00000001', 'hex');
         initiatorCredentialManager = new X509CertificateCredentialManager(
             [Buffer.from('3082012E3081D4A003020102021453423D5145C767CDC29895C3DB590192A611EA50300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333732345A170D3235313031393138333732345A30143112301006035504030C09696E69746961746F723059301306072A8648CE3D020106082A8648CE3D03010703420004EB0EF585F3992A1653CF310BF0F0F8035267CDAB6989C8B02E7228FBD759EF6B56263259AADF087F9849E7B7651F74C3B4F144CCCF86BB6FE2FF0EF3AA5FB5DC300A06082A8648CE3D0403020349003046022100D8C3AA7C98A730B3D4862EDAB4C1474FCD9A17A9CA3FB078914A10978FE95CC40221009F5877DD4E2C635A04ED1F6F1854C87B58521BDDFF533B1076F53D456739764C', 'hex')],
-            initiatorKeyID
+            Buffer.from('DC1FBB05B6B08360CE5B9EEA08EBFBFC6766A21340641863D4C8A3F68F096337', 'hex')
         );
         initiatorCredentialManager.addTrustedCA(trustedCA);
 
         const initiatorCryptoManager = new DefaultEdhocCryptoManager();
-        initiatorCryptoManager.addKey(initiatorKeyID, Buffer.from('DC1FBB05B6B08360CE5B9EEA08EBFBFC6766A21340641863D4C8A3F68F096337', 'hex'));
 
-        const responderKeyID = Buffer.from('00000002', 'hex');
         responderCredentialManager = new X509CertificateCredentialManager(
             [Buffer.from('3082012E3081D4A00302010202146648869E2608FC2E16D945C10E1F0192A6125CC0300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333735345A170D3235313031393138333735345A30143112301006035504030C09726573706F6E6465723059301306072A8648CE3D020106082A8648CE3D03010703420004161F76A7A106C9B79B7F651156B5B095E63A6101A39020F4E86DDACE61FB395E8AEF6CD9C444EE9A43DBD62DAD44FF50FE4146247D3AFD28F60DBC01FBFC573C300A06082A8648CE3D0403020349003046022100E8AD0926518CDB61E84D171700C7158FD0E72D03A117D40133ECD10F8B9F42CE022100E7E69B4C79100B3F0792F010AE11EE5DD2859C29EFC4DBCEFD41FA5CD4D3C3C9', 'hex')],
-            responderKeyID
+            Buffer.from('EE6287116FE27CDC539629DC87E12BF8EAA2229E7773AA67BC4C0FBA96E7FBB2', 'hex')
         );
         responderCredentialManager.addTrustedCA(trustedCA);
 
         const responderCryptoManager = new DefaultEdhocCryptoManager();
-        responderCryptoManager.addKey(responderKeyID, Buffer.from('EE6287116FE27CDC539629DC87E12BF8EAA2229E7773AA67BC4C0FBA96E7FBB2', 'hex'));
 
         // Initialize EDHOC instances
         initiator = new EDHOC(10, [EdhocMethod.Method1], [EdhocSuite.Suite2], initiatorCredentialManager, initiatorCryptoManager);
@@ -75,7 +77,7 @@ describe('EDHOC Handshake', () => {
         // Verify that both parties derived the same OSCORE security context
         const initiatorOSCORE = await initiator.exportOSCORE();
         const responderOSCORE = await responder.exportOSCORE();
-        
+
         expect(initiatorOSCORE.masterSalt).toEqual(responderOSCORE.masterSalt);
         expect(initiatorOSCORE.masterSecret).toEqual(responderOSCORE.masterSecret);
         expect(initiatorOSCORE.senderId).toEqual(responderOSCORE.recipientId);
@@ -113,7 +115,7 @@ describe('EDHOC Handshake', () => {
         it('messages should be the same', async () => {
             const initiatorCryptoManager = new StaticCryptoManager();
             const responderCryptoManager = new StaticCryptoManager();
-            
+
             initiator = new EDHOC(10, [EdhocMethod.Method1], [EdhocSuite.Suite2], initiatorCredentialManager, initiatorCryptoManager);
             responder = new EDHOC(20, [EdhocMethod.Method2, EdhocMethod.Method0, EdhocMethod.Method1], [EdhocSuite.Suite2], responderCredentialManager, responderCryptoManager);
 

--- a/test/c-library-vectors.test.ts
+++ b/test/c-library-vectors.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests against vectors from the C libedhoc library.
+ *
+ * Uses keys and certificates from:
+ *   - test_vector_x5chain_sign_keys_suite_2.h       (Method 0 - Sig/Sig)
+ *   - test_vector_x5chain_static_dh_keys_suite_2.h  (Method 3 - StaticDH/StaticDH)
+ *
+ * Also verifies the P-256 ECDH shared secret from RFC 9529 Chapter 3.
+ */
+
+import { X509Certificate } from 'crypto';
+import {
+    EDHOC,
+    X509CertificateCredentialManager,
+    DefaultEdhocCryptoManager,
+    EdhocMethod,
+    EdhocSuite,
+    EdhocCredentialManager,
+    EdhocCredentials,
+    EdhocCredentialsFormat,
+    EdhocCredentialsCertificateChain,
+    PublicPrivateTuple,
+} from '../dist/index';
+import { p256 } from '@noble/curves/p256';
+
+// ---------------------------------------------------------------------------
+// C libedhoc test vector data (P-256 / Suite 2)
+// Byte arrays taken verbatim from the C header files.
+// ---------------------------------------------------------------------------
+
+// Ephemeral keys (same in both sign and static_dh headers)
+const X_hex = '368ec1f69aeb659ba37d5a8d45b21bdc0299dceaa8ef235f3ca42ce3530f9525';
+const Y_hex = 'e2f4126777205e853b437d6eaca1e1f753cdcc3e2c69fa884b0a1a640977e418';
+
+// Static private keys
+const SK_I_hex = 'fb13adeb6518cee5f88417660841142e830a81fe334380a953406a1305e8706b';
+const SK_R_hex = '72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac';
+
+// Responder X.509 DER certificate (exact bytes from C header)
+const CRED_R = Buffer.from([
+    0x30, 0x82, 0x01, 0x1e, 0x30, 0x81, 0xc5, 0xa0, 0x03, 0x02, 0x01, 0x02,
+    0x02, 0x04, 0x61, 0xe9, 0x98, 0x1e, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86,
+    0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x30, 0x15, 0x31, 0x13, 0x30, 0x11,
+    0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x0a, 0x45, 0x44, 0x48, 0x4f, 0x43,
+    0x20, 0x52, 0x6f, 0x6f, 0x74, 0x30, 0x1e, 0x17, 0x0d, 0x32, 0x32, 0x30,
+    0x31, 0x32, 0x30, 0x31, 0x37, 0x31, 0x33, 0x30, 0x32, 0x5a, 0x17, 0x0d,
+    0x32, 0x39, 0x31, 0x32, 0x33, 0x31, 0x32, 0x33, 0x30, 0x30, 0x30, 0x30,
+    0x5a, 0x30, 0x1a, 0x31, 0x18, 0x30, 0x16, 0x06, 0x03, 0x55, 0x04, 0x03,
+    0x0c, 0x0f, 0x45, 0x44, 0x48, 0x4f, 0x43, 0x20, 0x52, 0x65, 0x73, 0x70,
+    0x6f, 0x6e, 0x64, 0x65, 0x72, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a,
+    0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce,
+    0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04, 0xbb, 0xc3, 0x49, 0x60,
+    0x52, 0x6e, 0xa4, 0xd3, 0x2e, 0x94, 0x0c, 0xad, 0x2a, 0x23, 0x41, 0x48,
+    0xdd, 0xc2, 0x17, 0x91, 0xa1, 0x2a, 0xfb, 0xcb, 0xac, 0x93, 0x62, 0x20,
+    0x46, 0xdd, 0x44, 0xf0, 0x45, 0x19, 0xe2, 0x57, 0x23, 0x6b, 0x2a, 0x0c,
+    0xe2, 0x02, 0x3f, 0x09, 0x31, 0xf1, 0xf3, 0x86, 0xca, 0x7a, 0xfd, 0xa6,
+    0x4f, 0xcd, 0xe0, 0x10, 0x8c, 0x22, 0x4c, 0x51, 0xea, 0xbf, 0x60, 0x72,
+    0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02,
+    0x03, 0x48, 0x00, 0x30, 0x45, 0x02, 0x20, 0x30, 0x19, 0x4e, 0xf5, 0xfc,
+    0x65, 0xc8, 0xb7, 0x95, 0xcd, 0xcd, 0x0b, 0xb4, 0x31, 0xbf, 0x83, 0xee,
+    0x67, 0x41, 0xc1, 0x37, 0x0c, 0x22, 0xc8, 0xeb, 0x8e, 0xe9, 0xed, 0xd2,
+    0xa7, 0x05, 0x19, 0x02, 0x21, 0x00, 0xb5, 0x83, 0x0e, 0x9c, 0x89, 0xa6,
+    0x2a, 0xc7, 0x3c, 0xe1, 0xeb, 0xce, 0x00, 0x61, 0x70, 0x7d, 0xb8, 0xa8,
+    0x8e, 0x23, 0x70, 0x9b, 0x4a, 0xcc, 0x58, 0xa1, 0x31, 0x3b, 0x13, 0x3d,
+    0x05, 0x58,
+]);
+
+// Initiator X.509 DER certificate (exact bytes from C header)
+const CRED_I = Buffer.from([
+    0x30, 0x82, 0x01, 0x1e, 0x30, 0x81, 0xc5, 0xa0, 0x03, 0x02, 0x01, 0x02,
+    0x02, 0x04, 0x62, 0x32, 0xef, 0x6f, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86,
+    0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x30, 0x15, 0x31, 0x13, 0x30, 0x11,
+    0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x0a, 0x45, 0x44, 0x48, 0x4f, 0x43,
+    0x20, 0x52, 0x6f, 0x6f, 0x74, 0x30, 0x1e, 0x17, 0x0d, 0x32, 0x32, 0x30,
+    0x33, 0x31, 0x37, 0x30, 0x38, 0x32, 0x31, 0x30, 0x33, 0x5a, 0x17, 0x0d,
+    0x32, 0x39, 0x31, 0x32, 0x33, 0x31, 0x32, 0x33, 0x30, 0x30, 0x30, 0x30,
+    0x5a, 0x30, 0x1a, 0x31, 0x18, 0x30, 0x16, 0x06, 0x03, 0x55, 0x04, 0x03,
+    0x0c, 0x0f, 0x45, 0x44, 0x48, 0x4f, 0x43, 0x20, 0x49, 0x6e, 0x69, 0x74,
+    0x69, 0x61, 0x74, 0x6f, 0x72, 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a,
+    0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce,
+    0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04, 0xac, 0x75, 0xe9, 0xec,
+    0xe3, 0xe5, 0x0b, 0xfc, 0x8e, 0xd6, 0x03, 0x99, 0x88, 0x95, 0x22, 0x40,
+    0x5c, 0x47, 0xbf, 0x16, 0xdf, 0x96, 0x66, 0x0a, 0x41, 0x29, 0x8c, 0xb4,
+    0x30, 0x7f, 0x7e, 0xb6, 0x6e, 0x5d, 0xe6, 0x11, 0x38, 0x8a, 0x4b, 0x8a,
+    0x82, 0x11, 0x33, 0x4a, 0xc7, 0xd3, 0x7e, 0xcb, 0x52, 0xa3, 0x87, 0xd2,
+    0x57, 0xe6, 0xdb, 0x3c, 0x2a, 0x93, 0xdf, 0x21, 0xff, 0x3a, 0xff, 0xc8,
+    0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02,
+    0x03, 0x48, 0x00, 0x30, 0x45, 0x02, 0x21, 0x00, 0x8c, 0x32, 0x3a, 0x1f,
+    0x33, 0x21, 0x38, 0xaa, 0xb9, 0xd0, 0xbe, 0xaf, 0xb8, 0x5f, 0x8d, 0x5a,
+    0x44, 0x07, 0x3c, 0x58, 0x0f, 0x59, 0x5b, 0xc5, 0x21, 0xef, 0x91, 0x3f,
+    0x6e, 0xf4, 0x8d, 0x11, 0x02, 0x20, 0x6c, 0x0a, 0xf1, 0xa1, 0x85, 0xa4,
+    0xe4, 0xde, 0x06, 0x35, 0x36, 0x99, 0x23, 0x1c, 0x73, 0x3a, 0x6e, 0x8d,
+    0xd2, 0xdf, 0x65, 0x13, 0x96, 0x6c, 0x91, 0x30, 0x15, 0x2a, 0x07, 0xa2,
+    0xbe, 0xde,
+]);
+
+// Expected ECDH shared secret (RFC 9529 Chapter 3)
+const G_XY_hex = '2f0cb7e860ba538fbf5c8bded009f6259b4b628fe1eb7dbe9378e5ecf7a824ba';
+
+// ---------------------------------------------------------------------------
+// Custom credential manager for C library vectors.
+// ---------------------------------------------------------------------------
+
+class CLibCredentialManager implements EdhocCredentialManager {
+    private ownCertDer: Buffer;
+    private peerCertDer: Buffer;
+    private privateKey: Buffer;
+
+    constructor(ownCertDer: Buffer, peerCertDer: Buffer, privateKey: Buffer) {
+        this.ownCertDer = ownCertDer;
+        this.peerCertDer = peerCertDer;
+        this.privateKey = privateKey;
+    }
+
+    async fetch(_edhoc: EDHOC): Promise<EdhocCredentials> {
+        return {
+            format: EdhocCredentialsFormat.x5chain,
+            privateKey: this.privateKey,
+            x5chain: {
+                certificates: [this.ownCertDer],
+            },
+        } as EdhocCredentialsCertificateChain;
+    }
+
+    async verify(_edhoc: EDHOC, credentials: EdhocCredentials): Promise<EdhocCredentials> {
+        if (credentials.format !== EdhocCredentialsFormat.x5chain) {
+            throw new Error('Expected x5chain credentials format');
+        }
+
+        const x5chain = (credentials as EdhocCredentialsCertificateChain).x5chain;
+        if (!x5chain || x5chain.certificates.length < 1) {
+            throw new Error('No certificates in chain');
+        }
+
+        const receivedCertDer = x5chain.certificates[0];
+
+        // Verify the received certificate matches the expected peer cert
+        if (!Buffer.from(receivedCertDer).equals(this.peerCertDer)) {
+            throw new Error('Received certificate does not match expected peer certificate');
+        }
+
+        // Extract the P-256 public key from the X.509 certificate
+        const x509 = new X509Certificate(receivedCertDer);
+        const jwk = x509.publicKey.export({ format: 'jwk' });
+        if (jwk.crv !== 'P-256') {
+            throw new Error(`Unsupported curve: ${jwk.crv}`);
+        }
+        const pubKey = Buffer.concat([
+            Buffer.from(jwk.x!, 'base64'),
+            Buffer.from(jwk.y!, 'base64'),
+        ]);
+
+        credentials.publicKey = pubKey;
+        return credentials;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Crypto manager that injects fixed ephemeral keys
+// ---------------------------------------------------------------------------
+
+class CLibVectorsCryptoManager extends DefaultEdhocCryptoManager {
+    private ephemeralKey: Buffer;
+
+    constructor(ephemeralKey: Buffer) {
+        super();
+        this.ephemeralKey = ephemeralKey;
+    }
+
+    generateKeyPair(edhoc: EDHOC): PublicPrivateTuple {
+        const privateKey = this.ephemeralKey;
+        // Suite 2 uses P-256
+        const publicKey = Buffer.from(p256.getPublicKey(privateKey)).subarray(1);
+        return { publicKey, privateKey };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create an EDHOC session for the C library vectors
+// ---------------------------------------------------------------------------
+
+function makeClibSession(
+    method: EdhocMethod,
+    role: 'initiator' | 'responder',
+): EDHOC {
+    const isInitiator = role === 'initiator';
+
+    const ownCert = isInitiator ? CRED_I : CRED_R;
+    const peerCert = isInitiator ? CRED_R : CRED_I;
+    const skHex = isInitiator ? SK_I_hex : SK_R_hex;
+    const ephHex = isInitiator ? X_hex : Y_hex;
+    const connID = isInitiator ? 0 : 1;
+
+    const credMgr = new CLibCredentialManager(ownCert, peerCert, Buffer.from(skHex, 'hex'));
+
+    const crypto = new CLibVectorsCryptoManager(Buffer.from(ephHex, 'hex'));
+
+    return new EDHOC(connID, [method], [EdhocSuite.Suite2], credMgr, crypto);
+}
+
+// ===========================================================================
+// 1. P-256 ECDH shared secret verification (RFC 9529 Chapter 3)
+// ===========================================================================
+
+describe('P-256 ECDH shared secret (RFC 9529 Chapter 3)', () => {
+    test('keyAgreement(X, G_Y) produces expected G_XY', async () => {
+        const crypto = new DefaultEdhocCryptoManager();
+        const credMgr = new X509CertificateCredentialManager([CRED_I], Buffer.alloc(0));
+        const edhoc = new EDHOC(
+            0,
+            [EdhocMethod.Method0],
+            [EdhocSuite.Suite2],
+            credMgr,
+            crypto,
+        );
+
+        // Derive G_Y from private key Y
+        const privateKeyY = Buffer.from(Y_hex, 'hex');
+        const G_Y = Buffer.from(p256.getPublicKey(privateKeyY)).subarray(1);
+
+        // Compute shared secret G_XY = ECDH(X, G_Y)
+        const privateKeyX = Buffer.from(X_hex, 'hex');
+        const sharedSecret = crypto.keyAgreement(edhoc, privateKeyX, G_Y);
+
+        // Verify against expected value
+        expect(sharedSecret.toString('hex')).toBe(G_XY_hex);
+    });
+});
+
+// ===========================================================================
+// 2. Method 0 (Sig/Sig) handshake with C library P-256 certificates
+// ===========================================================================
+
+describe('C library vectors: Method 0 (Sig/Sig) / Suite 2', () => {
+    let initiator: EDHOC;
+    let responder: EDHOC;
+
+    beforeEach(() => {
+        initiator = makeClibSession(EdhocMethod.Method0, 'initiator');
+        responder = makeClibSession(EdhocMethod.Method0, 'responder');
+    });
+
+    test('should complete a full handshake with OSCORE consistency', async () => {
+        // Three-message handshake
+        const message1 = await initiator.composeMessage1();
+        const ead1 = await responder.processMessage1(message1);
+        expect(ead1).toEqual([]);
+
+        const message2 = await responder.composeMessage2();
+        const ead2 = await initiator.processMessage2(message2);
+        expect(ead2).toEqual([]);
+
+        const message3 = await initiator.composeMessage3();
+        const ead3 = await responder.processMessage3(message3);
+        expect(ead3).toEqual([]);
+
+        // Verify OSCORE security context consistency
+        const iOSCORE = await initiator.exportOSCORE();
+        const rOSCORE = await responder.exportOSCORE();
+
+        expect(iOSCORE.masterSecret).toEqual(rOSCORE.masterSecret);
+        expect(iOSCORE.masterSalt).toEqual(rOSCORE.masterSalt);
+        expect(iOSCORE.senderId).toEqual(rOSCORE.recipientId);
+        expect(iOSCORE.recipientId).toEqual(rOSCORE.senderId);
+    });
+});
+
+// ===========================================================================
+// 3. Method 3 (StaticDH/StaticDH) handshake with C library P-256 certificates
+// ===========================================================================
+
+describe('C library vectors: Method 3 (StaticDH/StaticDH) / Suite 2', () => {
+    let initiator: EDHOC;
+    let responder: EDHOC;
+
+    beforeEach(() => {
+        initiator = makeClibSession(EdhocMethod.Method3, 'initiator');
+        responder = makeClibSession(EdhocMethod.Method3, 'responder');
+    });
+
+    test('should complete a full handshake with OSCORE consistency', async () => {
+        // Three-message handshake
+        const message1 = await initiator.composeMessage1();
+        const ead1 = await responder.processMessage1(message1);
+        expect(ead1).toEqual([]);
+
+        const message2 = await responder.composeMessage2();
+        const ead2 = await initiator.processMessage2(message2);
+        expect(ead2).toEqual([]);
+
+        const message3 = await initiator.composeMessage3();
+        const ead3 = await responder.processMessage3(message3);
+        expect(ead3).toEqual([]);
+
+        // Verify OSCORE security context consistency
+        const iOSCORE = await initiator.exportOSCORE();
+        const rOSCORE = await responder.exportOSCORE();
+
+        expect(iOSCORE.masterSecret).toEqual(rOSCORE.masterSecret);
+        expect(iOSCORE.masterSalt).toEqual(rOSCORE.masterSalt);
+        expect(iOSCORE.senderId).toEqual(rOSCORE.recipientId);
+        expect(iOSCORE.recipientId).toEqual(rOSCORE.senderId);
+    });
+});

--- a/test/cross-validation.test.ts
+++ b/test/cross-validation.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Cross-validation tests between TypeScript (node-edhoc) and Swift (SwiftEDHOC).
+ *
+ * Method 3 (StaticDH/StaticDH) has NO signatures, so all values are fully
+ * deterministic in both implementations — byte-exact cross-validation.
+ *
+ * Method 2 (StaticDH/Sig) has the responder sign. TS noble produces deterministic
+ * P-256 ECDSA signatures, while Swift CryptoKit produces hedged (randomized) ones.
+ * Values up to and including MAC_2 are deterministic; after that they diverge.
+ */
+
+import { EDHOC, X509CertificateCredentialManager, DefaultEdhocCryptoManager, EdhocMethod, EdhocSuite, PublicPrivateTuple } from '../dist/index';
+import { p256 } from '@noble/curves/p256';
+
+// Shared test data (same certificates/keys as BasicHandshakeTests and SwiftEDHOC CrossValidationTests)
+const trustedCA = Buffer.from('308201323081DAA003020102021478408C6EC18A1D452DAE70C726CB0192A6116DBB300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333635335A170D3235313031393138333635335A301A3118301606035504030C0F5468697320697320434120526F6F743059301306072A8648CE3D020106082A8648CE3D03010703420004B9348A8A267EF52CFDC30109A29008A2D99F6B8F78BA9EAF5D51578C06134E78CB90A073EDC2488A14174B4E2997C840C5DE7F8E35EB54A0DB6977E894D1B2CB300A06082A8648CE3D040302034700304402203B92BFEC770B0FA4E17F8F02A13CD945D914ED8123AC85C37C8C7BAA2BE3E0F102202CB2DC2EC295B5F4B7BB631ED751179C145D6B6E081559AEA38CE215369E9C31', 'hex');
+
+const initiatorCert = Buffer.from('3082012E3081D4A003020102021453423D5145C767CDC29895C3DB590192A611EA50300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333732345A170D3235313031393138333732345A30143112301006035504030C09696E69746961746F723059301306072A8648CE3D020106082A8648CE3D03010703420004EB0EF585F3992A1653CF310BF0F0F8035267CDAB6989C8B02E7228FBD759EF6B56263259AADF087F9849E7B7651F74C3B4F144CCCF86BB6FE2FF0EF3AA5FB5DC300A06082A8648CE3D0403020349003046022100D8C3AA7C98A730B3D4862EDAB4C1474FCD9A17A9CA3FB078914A10978FE95CC40221009F5877DD4E2C635A04ED1F6F1854C87B58521BDDFF533B1076F53D456739764C', 'hex');
+const initiatorKey = Buffer.from('DC1FBB05B6B08360CE5B9EEA08EBFBFC6766A21340641863D4C8A3F68F096337', 'hex');
+
+const responderCert = Buffer.from('3082012E3081D4A00302010202146648869E2608FC2E16D945C10E1F0192A6125CC0300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333735345A170D3235313031393138333735345A30143112301006035504030C09726573706F6E6465723059301306072A8648CE3D020106082A8648CE3D03010703420004161F76A7A106C9B79B7F651156B5B095E63A6101A39020F4E86DDACE61FB395E8AEF6CD9C444EE9A43DBD62DAD44FF50FE4146247D3AFD28F60DBC01FBFC573C300A06082A8648CE3D0403020349003046022100E8AD0926518CDB61E84D171700C7158FD0E72D03A117D40133ECD10F8B9F42CE022100E7E69B4C79100B3F0792F010AE11EE5DD2859C29EFC4DBCEFD41FA5CD4D3C3C9', 'hex');
+const responderKey = Buffer.from('EE6287116FE27CDC539629DC87E12BF8EAA2229E7773AA67BC4C0FBA96E7FBB2', 'hex');
+
+// Fixed ephemeral DH keys (P-256 private keys, 32 bytes)
+const initiatorEphemeral = Buffer.from('3717F87F867BC4C8AB4A564093F1CC4A5414C24DB2ED0690CFAC651A02A04010', 'hex');
+const responderEphemeral = Buffer.from('A7FFB1B45F2B570893B0E31C8AAF9C1C0E88C133E15CF2C0B89E5E3074B2D2A0', 'hex');
+
+const keyUpdateContext = Buffer.from('a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6', 'hex');
+
+class VectorsCryptoManager extends DefaultEdhocCryptoManager {
+    private ephemeralKey: Buffer;
+
+    constructor(ephemeralKey: Buffer) {
+        super();
+        this.ephemeralKey = ephemeralKey;
+    }
+
+    generateKeyPair(edhoc: EDHOC): PublicPrivateTuple {
+        const privateKey = this.ephemeralKey;
+        // Suite 2 uses P-256
+        const publicKey = Buffer.from(p256.getPublicKey(privateKey)).subarray(1);
+        return { publicKey, privateKey };
+    }
+}
+
+// Cross-validation vectors for Method 3 (StaticDH/StaticDH, Suite 2) — fully deterministic
+// RFC 9528: P-256 public keys use x-coordinate only (32 bytes) on the wire
+const swiftM3 = {
+    TH_1: '3d54fea658b0305dd50cb93f326f9b8ba8a5a68ce5ac3ee36571d740eae68e01',
+    TH_2: 'f3bacc9d43ea95fefa1a3547844158199655ff3e037440dbd83a9799d6f224dc',
+    PRK_2e: '843986712609a510a1feaa57486ffa6225d75a0a2bfd3dde5430a740e4779432',
+    PRK_3e2m: 'adadb2eb0e9d6626a6b417dd2892d9913da85b8dc3bc04ee0bc3675203c6dd05',
+    MAC_2: 'cad6bf389a35f360',
+    TH_3: 'b51d18370cd62188e45c02f60d7bf11e28c7ce6440505d548a0ffc421903ecc9',
+    PRK_4e3m: '980ea0be4c04fb6af82018404de816ac40d96c6d3cfc293fec387f429c6be552',
+    MAC_3: 'ab344668b80d4125',
+    TH_4: '526e9be77beef021cdd7845fba7f6730ec34cb0b198a58b9e2722762a3f040b3',
+    masterSecret: '8b5c8b7aa5b8a92e84dbdebc984fce09',
+    masterSalt: 'e530cbfc7783c8ca',
+    masterSecretAfterUpdate: '24feba33ff32da1a70cf9fd7ac94f03c',
+    masterSaltAfterUpdate: '0ca64d81411671b2',
+};
+
+// Cross-validation vectors for Method 2 (StaticDH/Sig, Suite 2) — deterministic up to MAC_2
+const swiftM2 = {
+    TH_1: '8656bb353c0f62546a8ea3c0fd13a59d7af2ef94deaeda10079c7a02d7159ff4',
+    TH_2: 'a5168d16f33ad812d6b5ba55f8a8400cf6bb624d01a45155fbe612e078b8bc3d',
+    PRK_2e: 'fbe3873abe6d8d24fb2324387fdd04eeccd1ea64fd49abdc98804bd23efcbf18',
+    PRK_3e2m: 'fbe3873abe6d8d24fb2324387fdd04eeccd1ea64fd49abdc98804bd23efcbf18',
+    MAC_2: '7b815c4fe241ac2492d95d548150e11fc874006398e2c901a91d62c6dd726ec8',
+};
+
+function makeSession(method: EdhocMethod, role: 'initiator' | 'responder', log: [string, string][]) {
+    const isInitiator = role === 'initiator';
+    const cert = isInitiator ? initiatorCert : responderCert;
+    const key = isInitiator ? initiatorKey : responderKey;
+    const ephemeral = isInitiator ? initiatorEphemeral : responderEphemeral;
+    const connID = isInitiator ? 10 : 20;
+
+    const credMgr = new X509CertificateCredentialManager([cert], key);
+    credMgr.addTrustedCA(trustedCA);
+
+    const crypto = new VectorsCryptoManager(ephemeral);
+
+    const session = new EDHOC(connID, [method], [EdhocSuite.Suite2], credMgr, crypto);
+    session.logger = (name: string, data: Buffer) => log.push([name, data.toString('hex')]);
+    return session;
+}
+
+function getVal(log: [string, string][], key: string): string | undefined {
+    return log.find(l => l[0] === key)?.[1];
+}
+
+describe('Cross-Validation: Swift <-> TypeScript', () => {
+
+    describe('Method 3 (StaticDH/StaticDH) / Suite 2 — fully deterministic', () => {
+        let iLog: [string, string][];
+        let rLog: [string, string][];
+        let initiator: EDHOC;
+        let responder: EDHOC;
+
+        beforeAll(async () => {
+            iLog = [];
+            rLog = [];
+            initiator = makeSession(EdhocMethod.Method3, 'initiator', iLog);
+            responder = makeSession(EdhocMethod.Method3, 'responder', rLog);
+
+            const msg1 = await initiator.composeMessage1();
+            await responder.processMessage1(msg1);
+            const msg2 = await responder.composeMessage2();
+            await initiator.processMessage2(msg2);
+            const msg3 = await initiator.composeMessage3();
+            await responder.processMessage3(msg3);
+        });
+
+        test('TH_1 matches Swift vector', () => {
+            expect(getVal(iLog, 'TH_1')).toBe(swiftM3.TH_1);
+        });
+
+        test('TH_2 matches Swift vector', () => {
+            expect(getVal(iLog, 'TH_2')).toBe(swiftM3.TH_2);
+        });
+
+        test('PRK_2e matches Swift vector', () => {
+            expect(getVal(iLog, 'PRK_2e')).toBe(swiftM3.PRK_2e);
+        });
+
+        test('PRK_3e2m matches Swift vector', () => {
+            expect(getVal(iLog, 'PRK_3e2m') || getVal(rLog, 'PRK_3e2m')).toBe(swiftM3.PRK_3e2m);
+        });
+
+        test('MAC_2 matches Swift vector', () => {
+            expect(getVal(rLog, 'MAC_2')).toBe(swiftM3.MAC_2);
+        });
+
+        test('TH_3 matches Swift vector', () => {
+            expect(getVal(iLog, 'TH_3') || getVal(rLog, 'TH_3')).toBe(swiftM3.TH_3);
+        });
+
+        test('PRK_4e3m matches Swift vector', () => {
+            expect(getVal(iLog, 'PRK_4e3m')).toBe(swiftM3.PRK_4e3m);
+        });
+
+        test('MAC_3 matches Swift vector', () => {
+            expect(getVal(iLog, 'MAC_3')).toBe(swiftM3.MAC_3);
+        });
+
+        test('TH_4 matches Swift vector', () => {
+            expect(getVal(iLog, 'TH_4')).toBe(swiftM3.TH_4);
+        });
+
+        test('OSCORE master secret matches Swift vector', async () => {
+            const iOSCORE = await initiator.exportOSCORE();
+            expect(iOSCORE.masterSecret.toString('hex')).toBe(swiftM3.masterSecret);
+        });
+
+        test('OSCORE master salt matches Swift vector', async () => {
+            const iOSCORE = await initiator.exportOSCORE();
+            expect(iOSCORE.masterSalt.toString('hex')).toBe(swiftM3.masterSalt);
+        });
+
+        test('OSCORE contexts match between initiator and responder', async () => {
+            const iOSCORE = await initiator.exportOSCORE();
+            const rOSCORE = await responder.exportOSCORE();
+
+            expect(iOSCORE.masterSecret).toEqual(rOSCORE.masterSecret);
+            expect(iOSCORE.masterSalt).toEqual(rOSCORE.masterSalt);
+            expect(iOSCORE.senderId).toEqual(rOSCORE.recipientId);
+            expect(iOSCORE.recipientId).toEqual(rOSCORE.senderId);
+        });
+
+        test('OSCORE after keyUpdate matches Swift vector', async () => {
+            await initiator.keyUpdate(keyUpdateContext);
+            await responder.keyUpdate(keyUpdateContext);
+
+            const iUpdated = await initiator.exportOSCORE();
+            const rUpdated = await responder.exportOSCORE();
+
+            expect(iUpdated.masterSecret.toString('hex')).toBe(swiftM3.masterSecretAfterUpdate);
+            expect(iUpdated.masterSalt.toString('hex')).toBe(swiftM3.masterSaltAfterUpdate);
+
+            expect(iUpdated.masterSecret).toEqual(rUpdated.masterSecret);
+            expect(iUpdated.masterSalt).toEqual(rUpdated.masterSalt);
+        });
+    });
+
+    describe('Method 2 (StaticDH/Sig) / Suite 2 — deterministic up to MAC_2', () => {
+        let iLog: [string, string][];
+        let rLog: [string, string][];
+        let initiator: EDHOC;
+        let responder: EDHOC;
+
+        beforeAll(async () => {
+            iLog = [];
+            rLog = [];
+            initiator = makeSession(EdhocMethod.Method2, 'initiator', iLog);
+            responder = makeSession(EdhocMethod.Method2, 'responder', rLog);
+
+            const msg1 = await initiator.composeMessage1();
+            await responder.processMessage1(msg1);
+            const msg2 = await responder.composeMessage2();
+            await initiator.processMessage2(msg2);
+            const msg3 = await initiator.composeMessage3();
+            await responder.processMessage3(msg3);
+        });
+
+        test('TH_1 matches Swift vector', () => {
+            expect(getVal(iLog, 'TH_1')).toBe(swiftM2.TH_1);
+        });
+
+        test('TH_2 matches Swift vector', () => {
+            expect(getVal(iLog, 'TH_2')).toBe(swiftM2.TH_2);
+        });
+
+        test('PRK_2e matches Swift vector', () => {
+            expect(getVal(iLog, 'PRK_2e')).toBe(swiftM2.PRK_2e);
+        });
+
+        test('PRK_3e2m matches Swift vector', () => {
+            expect(getVal(iLog, 'PRK_3e2m') || getVal(rLog, 'PRK_3e2m')).toBe(swiftM2.PRK_3e2m);
+        });
+
+        test('MAC_2 matches Swift vector', () => {
+            expect(getVal(rLog, 'MAC_2')).toBe(swiftM2.MAC_2);
+        });
+
+        test('OSCORE contexts match between initiator and responder', async () => {
+            const iOSCORE = await initiator.exportOSCORE();
+            const rOSCORE = await responder.exportOSCORE();
+
+            expect(iOSCORE.masterSecret).toEqual(rOSCORE.masterSecret);
+            expect(iOSCORE.masterSalt).toEqual(rOSCORE.masterSalt);
+            expect(iOSCORE.senderId).toEqual(rOSCORE.recipientId);
+            expect(iOSCORE.recipientId).toEqual(rOSCORE.senderId);
+        });
+
+        test('keyUpdate produces consistent OSCORE contexts', async () => {
+            await initiator.keyUpdate(keyUpdateContext);
+            await responder.keyUpdate(keyUpdateContext);
+
+            const iUpdated = await initiator.exportOSCORE();
+            const rUpdated = await responder.exportOSCORE();
+
+            expect(iUpdated.masterSecret).toEqual(rUpdated.masterSecret);
+            expect(iUpdated.masterSalt).toEqual(rUpdated.masterSalt);
+        });
+    });
+});

--- a/test/generate-vectors.ts
+++ b/test/generate-vectors.ts
@@ -1,0 +1,115 @@
+/**
+ * Generate cross-validation test vectors for Methods 2 and 3 with Suite 2 (P-256).
+ *
+ * Method 3 (StaticDH/StaticDH) has NO signatures, so all values are fully
+ * deterministic in both TypeScript (noble) and Swift (CryptoKit).
+ *
+ * Method 2 (StaticDH/Sig) has the responder sign, so TS produces deterministic
+ * signatures while Swift (CryptoKit) produces hedged ones. All values before
+ * Signature_or_MAC_2 are deterministic in both.
+ */
+
+import { EDHOC, X509CertificateCredentialManager, DefaultEdhocCryptoManager, EdhocMethod, EdhocSuite, PublicPrivateTuple } from '../dist/index';
+import { p256 } from '@noble/curves/p256';
+
+// Shared test data (same certificates/keys as BasicHandshakeTests)
+const trustedCA = Buffer.from('308201323081DAA003020102021478408C6EC18A1D452DAE70C726CB0192A6116DBB300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333635335A170D3235313031393138333635335A301A3118301606035504030C0F5468697320697320434120526F6F743059301306072A8648CE3D020106082A8648CE3D03010703420004B9348A8A267EF52CFDC30109A29008A2D99F6B8F78BA9EAF5D51578C06134E78CB90A073EDC2488A14174B4E2997C840C5DE7F8E35EB54A0DB6977E894D1B2CB300A06082A8648CE3D040302034700304402203B92BFEC770B0FA4E17F8F02A13CD945D914ED8123AC85C37C8C7BAA2BE3E0F102202CB2DC2EC295B5F4B7BB631ED751179C145D6B6E081559AEA38CE215369E9C31', 'hex');
+
+const initiatorCert = Buffer.from('3082012E3081D4A003020102021453423D5145C767CDC29895C3DB590192A611EA50300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333732345A170D3235313031393138333732345A30143112301006035504030C09696E69746961746F723059301306072A8648CE3D020106082A8648CE3D03010703420004EB0EF585F3992A1653CF310BF0F0F8035267CDAB6989C8B02E7228FBD759EF6B56263259AADF087F9849E7B7651F74C3B4F144CCCF86BB6FE2FF0EF3AA5FB5DC300A06082A8648CE3D0403020349003046022100D8C3AA7C98A730B3D4862EDAB4C1474FCD9A17A9CA3FB078914A10978FE95CC40221009F5877DD4E2C635A04ED1F6F1854C87B58521BDDFF533B1076F53D456739764C', 'hex');
+const initiatorKey = Buffer.from('DC1FBB05B6B08360CE5B9EEA08EBFBFC6766A21340641863D4C8A3F68F096337', 'hex');
+
+const responderCert = Buffer.from('3082012E3081D4A00302010202146648869E2608FC2E16D945C10E1F0192A6125CC0300A06082A8648CE3D040302301A3118301606035504030C0F5468697320697320434120526F6F74301E170D3234313031393138333735345A170D3235313031393138333735345A30143112301006035504030C09726573706F6E6465723059301306072A8648CE3D020106082A8648CE3D03010703420004161F76A7A106C9B79B7F651156B5B095E63A6101A39020F4E86DDACE61FB395E8AEF6CD9C444EE9A43DBD62DAD44FF50FE4146247D3AFD28F60DBC01FBFC573C300A06082A8648CE3D0403020349003046022100E8AD0926518CDB61E84D171700C7158FD0E72D03A117D40133ECD10F8B9F42CE022100E7E69B4C79100B3F0792F010AE11EE5DD2859C29EFC4DBCEFD41FA5CD4D3C3C9', 'hex');
+const responderKey = Buffer.from('EE6287116FE27CDC539629DC87E12BF8EAA2229E7773AA67BC4C0FBA96E7FBB2', 'hex');
+
+// Fixed ephemeral DH keys (P-256 private keys, 32 bytes)
+const initiatorEphemeral = Buffer.from('3717F87F867BC4C8AB4A564093F1CC4A5414C24DB2ED0690CFAC651A02A04010', 'hex');
+const responderEphemeral = Buffer.from('A7FFB1B45F2B570893B0E31C8AAF9C1C0E88C133E15CF2C0B89E5E3074B2D2A0', 'hex');
+
+class VectorsCryptoManager extends DefaultEdhocCryptoManager {
+    private ephemeralKey: Buffer;
+
+    constructor(ephemeralKey: Buffer) {
+        super();
+        this.ephemeralKey = ephemeralKey;
+    }
+
+    generateKeyPair(edhoc: EDHOC): PublicPrivateTuple {
+        const privateKey = this.ephemeralKey;
+        // Suite 2 uses P-256
+        const publicKey = Buffer.from(p256.getPublicKey(privateKey)).subarray(1);
+        return { publicKey, privateKey };
+    }
+}
+
+async function generateVectors(method: EdhocMethod, methodName: string) {
+    const iLog: [string, string][] = [];
+    const rLog: [string, string][] = [];
+
+    const iCredMgr = new X509CertificateCredentialManager([initiatorCert], initiatorKey);
+    iCredMgr.addTrustedCA(trustedCA);
+
+    const iCrypto = new VectorsCryptoManager(initiatorEphemeral);
+
+    const rCredMgr = new X509CertificateCredentialManager([responderCert], responderKey);
+    rCredMgr.addTrustedCA(trustedCA);
+
+    const rCrypto = new VectorsCryptoManager(responderEphemeral);
+
+    const initiator = new EDHOC(10, [method], [EdhocSuite.Suite2], iCredMgr, iCrypto);
+    const responder = new EDHOC(20, [method], [EdhocSuite.Suite2], rCredMgr, rCrypto);
+
+    initiator.logger = (name: string, data: Buffer) => iLog.push([name, data.toString('hex')]);
+    responder.logger = (name: string, data: Buffer) => rLog.push([name, data.toString('hex')]);
+
+    // Three-message handshake
+    const msg1 = await initiator.composeMessage1();
+    await responder.processMessage1(msg1);
+
+    const msg2 = await responder.composeMessage2();
+    await initiator.processMessage2(msg2);
+
+    const msg3 = await initiator.composeMessage3();
+    await responder.processMessage3(msg3);
+
+    // Export OSCORE
+    const iOSCORE = await initiator.exportOSCORE();
+    const rOSCORE = await responder.exportOSCORE();
+
+    // Key update
+    const keyUpdateContext = Buffer.from('a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6', 'hex');
+    await initiator.keyUpdate(keyUpdateContext);
+    await responder.keyUpdate(keyUpdateContext);
+    const iOSCOREUpdated = await initiator.exportOSCORE();
+
+    console.log(`\n=== ${methodName} / Suite 2 (P-256) ===\n`);
+
+    // Print all logged values
+    for (const key of ['message_1', 'TH_1', 'G_Y', 'G_XY', 'TH_2', 'PRK_2e', 'PRK_3e2m',
+                        'MAC_2', 'Signature_or_MAC_2', 'PLAINTEXT_2', 'CIPHERTEXT_2', 'TH_3',
+                        'PRK_4e3m', 'MAC_3', 'Signature_or_MAC_3', 'PLAINTEXT_3', 'CIPHERTEXT_3', 'TH_4',
+                        'message_2', 'message_3']) {
+        const iVal = iLog.find(l => l[0] === key)?.[1];
+        const rVal = rLog.find(l => l[0] === key)?.[1];
+        const val = iVal || rVal;
+        if (val) {
+            const tag = iVal && rVal && iVal !== rVal ? ' (I/R DIFFER)' : '';
+            console.log(`${key}: ${val}${tag}`);
+        }
+    }
+
+    console.log(`\nOSCORE:`);
+    console.log(`  masterSecret: ${iOSCORE.masterSecret.toString('hex')}`);
+    console.log(`  masterSalt:   ${iOSCORE.masterSalt.toString('hex')}`);
+    console.log(`  i.senderId:   ${iOSCORE.senderId.toString('hex')}`);
+    console.log(`  i.recipientId:${iOSCORE.recipientId.toString('hex')}`);
+    console.log(`  match: secret=${iOSCORE.masterSecret.equals(rOSCORE.masterSecret)} salt=${iOSCORE.masterSalt.equals(rOSCORE.masterSalt)}`);
+
+    console.log(`\nOSCORE after keyUpdate(a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6):`);
+    console.log(`  masterSecret: ${iOSCOREUpdated.masterSecret.toString('hex')}`);
+    console.log(`  masterSalt:   ${iOSCOREUpdated.masterSalt.toString('hex')}`);
+}
+
+(async () => {
+    await generateVectors(EdhocMethod.Method3, 'Method 3 (StaticDH/StaticDH)');
+    await generateVectors(EdhocMethod.Method2, 'Method 2 (StaticDH/Sig)');
+})();

--- a/test/rfc9529-chapter3-vectors.test.ts
+++ b/test/rfc9529-chapter3-vectors.test.ts
@@ -1,0 +1,244 @@
+/**
+ * RFC 9529 Chapter 3 test vectors — Method 3 (StaticDH/StaticDH), Suite 2,
+ * CCS/kid credentials.
+ *
+ * Verifies the TypeScript EDHOC library against the reference vectors from
+ * the C libedhoc library's test_vector_ccs_static_dh_keys_suite_2.h header,
+ * which implements the RFC 9529 Chapter 3 scenario with CCS (CBOR Certificate
+ * Structures) and kid-based credential identification.
+ *
+ * Key differences from X.509 test vectors:
+ *   - ID_CRED_x on the wire uses compact form: bare CBOR integer (e.g., 0x32)
+ *   - ID_CRED_x in MAC context / Sig_structure uses full map: {4: bstr(cbor(kid))}
+ *   - CRED_x is a raw CBOR map (CCS), NOT bstr-wrapped
+ */
+
+import {
+    EDHOC,
+    DefaultEdhocCryptoManager,
+    EdhocMethod,
+    EdhocSuite,
+    CCSCredentialManager,
+    PublicPrivateTuple,
+} from '../dist/index';
+import { p256 } from '@noble/curves/p256';
+
+// ---------------------------------------------------------------------------
+// Test vector data from C libedhoc: test_vector_ccs_static_dh_keys_suite_2.h
+// ---------------------------------------------------------------------------
+
+// Ephemeral DH private keys (P-256)
+const X_hex = '368ec1f69aeb659ba37d5a8d45b21bdc0299dceaa8ef235f3ca42ce3530f9525';
+const Y_hex = 'e2f4126777205e853b437d6eaca1e1f753cdcc3e2c69fa884b0a1a640977e418';
+
+// Static authentication private keys (P-256)
+const SK_I_hex = 'fb13adeb6518cee5f88417660841142e830a81fe334380a953406a1305e8706b';
+const SK_R_hex = '72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac';
+
+// P-256 public keys (x-coordinate only, 32 bytes)
+const PK_I_hex = 'ac75e9ece3e50bfc8ed60399889522405c47bf16df96660a41298cb4307f7eb6';
+const PK_R_hex = 'bbc34960526ea4d32e940cad2a234148ddc21791a12afbcbac93622046dd44f0';
+
+// Connection identifiers
+const C_I = -24;
+const C_R = -8;
+
+// kid values
+const KID_I = -12;  // CBOR encoding: 0x2b
+const KID_R = -19;  // CBOR encoding: 0x32
+
+// CRED_R: CCS CBOR map (verbatim from C header CRED_R_cborised[])
+const CRED_R = Buffer.from([
+    0xa2, 0x02, 0x6b, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x65,
+    0x64, 0x75, 0x08, 0xa1, 0x01, 0xa5, 0x01, 0x02, 0x02, 0x41, 0x32, 0x20,
+    0x01, 0x21, 0x58, 0x20, 0xbb, 0xc3, 0x49, 0x60, 0x52, 0x6e, 0xa4, 0xd3,
+    0x2e, 0x94, 0x0c, 0xad, 0x2a, 0x23, 0x41, 0x48, 0xdd, 0xc2, 0x17, 0x91,
+    0xa1, 0x2a, 0xfb, 0xcb, 0xac, 0x93, 0x62, 0x20, 0x46, 0xdd, 0x44, 0xf0,
+    0x22, 0x58, 0x20, 0x45, 0x19, 0xe2, 0x57, 0x23, 0x6b, 0x2a, 0x0c, 0xe2,
+    0x02, 0x3f, 0x09, 0x31, 0xf1, 0xf3, 0x86, 0xca, 0x7a, 0xfd, 0xa6, 0x4f,
+    0xcd, 0xe0, 0x10, 0x8c, 0x22, 0x4c, 0x51, 0xea, 0xbf, 0x60, 0x72,
+]);
+
+// CRED_I: CCS CBOR map (verbatim from C header CRED_I_cborised[])
+const CRED_I = Buffer.from([
+    0xa2, 0x02, 0x77, 0x34, 0x32, 0x2d, 0x35, 0x30, 0x2d, 0x33, 0x31, 0x2d,
+    0x46, 0x46, 0x2d, 0x45, 0x46, 0x2d, 0x33, 0x37, 0x2d, 0x33, 0x32, 0x2d,
+    0x33, 0x39, 0x08, 0xa1, 0x01, 0xa5, 0x01, 0x02, 0x02, 0x41, 0x2b, 0x20,
+    0x01, 0x21, 0x58, 0x20, 0xac, 0x75, 0xe9, 0xec, 0xe3, 0xe5, 0x0b, 0xfc,
+    0x8e, 0xd6, 0x03, 0x99, 0x88, 0x95, 0x22, 0x40, 0x5c, 0x47, 0xbf, 0x16,
+    0xdf, 0x96, 0x66, 0x0a, 0x41, 0x29, 0x8c, 0xb4, 0x30, 0x7f, 0x7e, 0xb6,
+    0x22, 0x58, 0x20, 0x6e, 0x5d, 0xe6, 0x11, 0x38, 0x8a, 0x4b, 0x8a, 0x82,
+    0x11, 0x33, 0x4a, 0xc7, 0xd3, 0x7e, 0xcb, 0x52, 0xa3, 0x87, 0xd2, 0x57,
+    0xe6, 0xdb, 0x3c, 0x2a, 0x93, 0xdf, 0x21, 0xff, 0x3a, 0xff, 0xc8,
+]);
+
+// Expected intermediate values from C library vectors
+const expected = {
+    H_message_1: 'ca02cabda5a8902749b42f711050bb4dbd52153e87527594b39f50cdf019888c',
+    TH_2: '356efd53771425e008f3fe3a86c83ff4c6b16e57028ff39d5236c182b202084b',
+    PRK_2e: '5aa0d69f3e3d1e0c479f0b8a486690c9802630c3466b1dc92371c982563170b5',
+    PRK_3e2m: '0ca3d3398296b3c03900987620c11f6fce70781c1d1219720f9ec08c122d8434',
+    MAC_2: '0943305c899f5c54',
+    TH_3: 'adaf67a78a4bcc91e018f8882762a722000b2507039df0bc1bbf0c161bb3155c',
+    PRK_4e3m: '81cc8a298e357044e3c466bb5c0a1e507e01d49238aeba138df94635407c0ff7',
+    MAC_3: '623c91df41e34c2f',
+    TH_4: 'c902b1e3a4326c93c5551f5f3aa6c5ecc0246806765612e52b5d99e6059d6b6e',
+    OSCORE_masterSecret: 'f9868f6a3aca78a05d1485b35030b162',
+    OSCORE_masterSalt: 'ada24c7dbfc85eeb',
+    // OSCORE IDs: CBOR encoding of connection IDs
+    // C_I = -24 -> CBOR byte = 0x37, C_R = -8 -> CBOR byte = 0x27
+    OSCORE_C_I: '37',
+    OSCORE_C_R: '27',
+};
+
+// ---------------------------------------------------------------------------
+// Crypto manager with fixed ephemeral keys
+// ---------------------------------------------------------------------------
+
+class CCSVectorsCryptoManager extends DefaultEdhocCryptoManager {
+    private ephemeralKey: Buffer;
+
+    constructor(ephemeralKey: Buffer) {
+        super();
+        this.ephemeralKey = ephemeralKey;
+    }
+
+    generateKeyPair(edhoc: EDHOC): PublicPrivateTuple {
+        const privateKey = this.ephemeralKey;
+        // Suite 2 uses P-256
+        const publicKey = Buffer.from(p256.getPublicKey(privateKey)).subarray(1);
+        return { publicKey, privateKey };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create an EDHOC session for CCS/kid vectors
+// ---------------------------------------------------------------------------
+
+function makeCCSSession(
+    role: 'initiator' | 'responder',
+    log: [string, string][],
+): EDHOC {
+    const isInitiator = role === 'initiator';
+
+    const ownKid = isInitiator ? KID_I : KID_R;
+    const ownCred = isInitiator ? CRED_I : CRED_R;
+    const ownPK = Buffer.from(isInitiator ? PK_I_hex : PK_R_hex, 'hex');
+    const peerKid = isInitiator ? KID_R : KID_I;
+    const peerCred = isInitiator ? CRED_R : CRED_I;
+    const peerPK = Buffer.from(isInitiator ? PK_R_hex : PK_I_hex, 'hex');
+    const skHex = isInitiator ? SK_I_hex : SK_R_hex;
+    const ephHex = isInitiator ? X_hex : Y_hex;
+    const connID = isInitiator ? C_I : C_R;
+
+    const credMgr = new CCSCredentialManager();
+    credMgr.addOwnCredential(ownKid, ownCred, ownPK, Buffer.from(skHex, 'hex'));
+    credMgr.addPeerCredential(peerKid, peerCred, peerPK);
+
+    const crypto = new CCSVectorsCryptoManager(Buffer.from(ephHex, 'hex'));
+
+    // C vector: SUITES_I = [6, 2] (selected = 2). Initiator lists both; responder only needs the selected suite.
+    const suites = isInitiator
+        ? [EdhocSuite.Suite6, EdhocSuite.Suite2]
+        : [EdhocSuite.Suite2];
+    const session = new EDHOC(connID, [EdhocMethod.Method3], suites, credMgr, crypto);
+    session.logger = (name: string, data: Buffer) => log.push([name, data.toString('hex')]);
+    return session;
+}
+
+function getVal(log: [string, string][], key: string): string | undefined {
+    return log.find(l => l[0] === key)?.[1];
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe('RFC 9529 Chapter 3: Method 3 (StaticDH/StaticDH), Suite 2, CCS/kid', () => {
+    let iLog: [string, string][];
+    let rLog: [string, string][];
+    let initiator: EDHOC;
+    let responder: EDHOC;
+
+    beforeAll(async () => {
+        iLog = [];
+        rLog = [];
+        initiator = makeCCSSession('initiator', iLog);
+        responder = makeCCSSession('responder', rLog);
+
+        const msg1 = await initiator.composeMessage1();
+        await responder.processMessage1(msg1);
+        const msg2 = await responder.composeMessage2();
+        await initiator.processMessage2(msg2);
+        const msg3 = await initiator.composeMessage3();
+        await responder.processMessage3(msg3);
+    });
+
+    test('H(message_1) matches expected vector', () => {
+        expect(getVal(iLog, 'TH_1')).toBe(expected.H_message_1);
+    });
+
+    test('TH_2 matches expected vector', () => {
+        expect(getVal(rLog, 'TH_2')).toBe(expected.TH_2);
+    });
+
+    test('PRK_2e matches expected vector', () => {
+        expect(getVal(rLog, 'PRK_2e')).toBe(expected.PRK_2e);
+    });
+
+    test('PRK_3e2m matches expected vector', () => {
+        expect(getVal(rLog, 'PRK_3e2m')).toBe(expected.PRK_3e2m);
+    });
+
+    test('MAC_2 matches expected vector', () => {
+        expect(getVal(rLog, 'MAC_2')).toBe(expected.MAC_2);
+    });
+
+    test('TH_3 matches expected vector', () => {
+        // TH_3 is computed by both sides; check both
+        const rTH3 = getVal(rLog, 'TH_3');
+        const iTH3 = getVal(iLog, 'TH_3');
+        expect(rTH3).toBe(expected.TH_3);
+        expect(iTH3).toBe(expected.TH_3);
+    });
+
+    test('PRK_4e3m matches expected vector', () => {
+        expect(getVal(iLog, 'PRK_4e3m')).toBe(expected.PRK_4e3m);
+    });
+
+    test('MAC_3 matches expected vector', () => {
+        expect(getVal(iLog, 'MAC_3')).toBe(expected.MAC_3);
+    });
+
+    test('TH_4 matches expected vector', () => {
+        expect(getVal(iLog, 'TH_4')).toBe(expected.TH_4);
+    });
+
+    test('OSCORE master secret matches expected vector', async () => {
+        const iOSCORE = await initiator.exportOSCORE();
+        expect(iOSCORE.masterSecret.toString('hex')).toBe(expected.OSCORE_masterSecret);
+    });
+
+    test('OSCORE master salt matches expected vector', async () => {
+        const iOSCORE = await initiator.exportOSCORE();
+        expect(iOSCORE.masterSalt.toString('hex')).toBe(expected.OSCORE_masterSalt);
+    });
+
+    test('OSCORE sender/recipient IDs use correct CBOR encoding', async () => {
+        const iOSCORE = await initiator.exportOSCORE();
+        // Initiator Sender ID = connectionIdToBytes(C_R) = CBOR(-8) = 0x27
+        expect(iOSCORE.senderId.toString('hex')).toBe(expected.OSCORE_C_R);
+        // Initiator Recipient ID = connectionIdToBytes(C_I) = CBOR(-24) = 0x37
+        expect(iOSCORE.recipientId.toString('hex')).toBe(expected.OSCORE_C_I);
+    });
+
+    test('OSCORE contexts match between initiator and responder', async () => {
+        const iOSCORE = await initiator.exportOSCORE();
+        const rOSCORE = await responder.exportOSCORE();
+
+        expect(iOSCORE.masterSecret).toEqual(rOSCORE.masterSecret);
+        expect(iOSCORE.masterSalt).toEqual(rOSCORE.masterSalt);
+        expect(iOSCORE.senderId).toEqual(rOSCORE.recipientId);
+        expect(iOSCORE.recipientId).toEqual(rOSCORE.senderId);
+    });
+});


### PR DESCRIPTION
Replace the C-style import/destroy key lifecycle with direct byte parameters
on all crypto operations. The keystore dictionary and auto-incrementing ID
generation was pure overhead — keys were stored as raw bytes and crypto
objects were created on-demand for each operation anyway.

Changes to the crypto interface (EdhocCryptoManager):
- Remove importKey(), destroyKey(), makeKeyPair(), addKey()
- Remove EdhocKeyType enum
- Add generateKeyPair(edhoc) returning { publicKey, privateKey }
- All operations now take raw Buffer params instead of opaque key IDs:
  keyAgreement(edhoc, privateKey, peerPublicKey),
  sign(edhoc, privateKey, input), verify(edhoc, publicKey, input, signature),
  hkdfExtract(edhoc, ikm, salt), hkdfExpand(edhoc, prk, info, length),
  encrypt/decrypt(edhoc, key, nonce, aad, plaintext/ciphertext),
  hash(edhoc, input)

Credential model: privateKeyID → privateKey (raw bytes, not a handle).
Session state: ephKeyId → ephPrivateKey. Cleanup just nils the reference.

Also adds CCS credential manager, additional test suites (C library vectors,
cross-validation, RFC 9529 Chapter 3), CBOR utility improvements, and
expanded README documentation.